### PR TITLE
fix: BoardCellModel reconstruction

### DIFF
--- a/Yut/Yut/Features/GamePlay/Models/BoardCellModel.swift
+++ b/Yut/Yut/Features/GamePlay/Models/BoardCellModel.swift
@@ -5,34 +5,31 @@
 //  Created by Seungeun Park on 7/18/25.
 //
 
-import ARKit
-
 class BoardCellModel {
-    weak var board: BoardModel?
-    let row: Int
-    let col: Int
-    var id: String { "_\(row)_\(col)" }
-    
-    let position: SIMD2<Int>
-    var anchor : ARAnchor?
-    
-    var isActive: Bool {
-        board?.activeCells.contains(where: { $0 === self }) ?? false
-    }
-    var isBranchPoint: Bool {
-        board?.branchPoints.contains(where: { $0 === self }) ?? false
-    }
-    var nextCandidates: [(row: Int, col: Int)] = []
-    
-    var isGoal: Bool {
-            return row == 6 && col == 6
-        }
-    
-    init(row: Int, col: Int, position: SIMD2<Int>, isActive: Bool, isBranchPoint: Bool) {
-        self.row = row
-        self.col = col
-        self.position = position
-    }
-    
-}
+    let id: String
+    private(set) var pieces: [PieceModel] = []
 
+    init(id: String) {
+        self.id = id
+    }
+
+    func enter(_ newPiece: PieceModel) {
+        let sameOwner = pieces.allSatisfy { $0.owner.name == newPiece.owner.name }
+
+        if sameOwner {
+            pieces.append(newPiece)
+        } else {
+            for piece in pieces {
+                piece.leaveCell(captured: true) // piece가 알아서 boardCell.leave(self)를 호출
+            }
+            pieces.removeAll()
+            pieces.append(newPiece)
+        }
+    }
+
+    func leave(_ piece: PieceModel) {
+        if let index = pieces.firstIndex(where: { $0 === piece }) {
+            pieces.remove(at: index)
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->
기존 행과 열을 입력 받고 아이디를 setting하는 로직에서 
각 칸의 이름과 각 칸에 들어오는 enter(), 나가는 leave()를 구현해서 업히고 잡는 로직을 단순화 했습니다

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->
원래는 복잡했음
지금은 업고 잡는 로직이 간단해졌어용

원래 있던 말의 owner과 새로 들어온 말의 owner가 같으면 그냥 셀에 두 말 모두 담고 (업기)
만약에 다르면 원래 있던 말들을 모두 지우고 새로운 말을 추가하도록 했습니다 (잡기)

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: Closes #123
-->
Closes #61
