### PR TITLE
Feat: 윷 던진 결과에 따른 말 이동 구현

### DIFF
--- a/Yut/Yut.xcodeproj/project.pbxproj
+++ b/Yut/Yut.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		277D74AD2E28887900DE2A2E /* Exceptions for "Yut" folder in "Yut" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Core/Models/.gitkeep,
 				Info.plist,
 			);
 			target = 69DF5E332E209A4600CE5E2A /* Yut */;
@@ -411,7 +410,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = NBC28VW8Q2;
+				DEVELOPMENT_TEAM = H2WD8C55D7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Yut/Info.plist;
@@ -426,7 +425,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = HappyJay.Yut;
+				PRODUCT_BUNDLE_IDENTIFIER = HappyJay.Yut2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -441,7 +440,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = NBC28VW8Q2;
+				DEVELOPMENT_TEAM = H2WD8C55D7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Yut/Info.plist;
@@ -456,7 +455,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = HappyJay.Yut;
+				PRODUCT_BUNDLE_IDENTIFIER = HappyJay.Yut2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Yut/Yut/APP/YutApp.swift
+++ b/Yut/Yut/APP/YutApp.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct YutApp: App {
     var body: some Scene {
         WindowGroup {
-//            PlayView()
-            RootView()
+            PlayView()
+//            RootView()
         }
     }
 }

--- a/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
+++ b/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
@@ -4,15 +4,15 @@ import Combine
 
 /// ARView의 이벤트를 처리하고 SwiftUI 상태와 연결해주는 총괄 Coordinator
 class ARCoordinator: NSObject, ARSessionDelegate {
-
+    
     // MARK: - 외부 연결 (의존 객체)
-
+    
     weak var arView: ARView? {
         didSet {
             gestureHandler.arView = arView
         }
     }
-
+    
     var arState: ARState? {
         didSet {
             if let arState {
@@ -20,7 +20,7 @@ class ARCoordinator: NSObject, ARSessionDelegate {
             }
         }
     }
-
+    
     // MARK: - 서브 매니저
     
     var gestureHandler: GestureHandler!
@@ -31,7 +31,7 @@ class ARCoordinator: NSObject, ARSessionDelegate {
     var actionStreamHandler: ActionStreamHandler!
     
     // MARK: - 초기화
-
+    
     override init() {
         super.init()
         self.boardManager = BoardManager(coordinator: self)
@@ -41,9 +41,9 @@ class ARCoordinator: NSObject, ARSessionDelegate {
         self.gestureHandler = GestureHandler(coordinator: self)
         self.actionStreamHandler = ActionStreamHandler(coordinator: self)
     }
-
+    
     // MARK: - ARSessionDelegate (앵커 업데이트 처리)
-
+    
     func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
         for anchor in anchors {
             if let planeAnchor = anchor as? ARPlaneAnchor {
@@ -53,10 +53,10 @@ class ARCoordinator: NSObject, ARSessionDelegate {
             }
         }
     }
-
+    
     func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
         var recognizedArea: Float = 0.0
-
+        
         for anchor in anchors {
             guard let planeAnchor = anchor as? ARPlaneAnchor else { continue }
             planeManager.updatePlane(for: planeAnchor)
@@ -67,13 +67,49 @@ class ARCoordinator: NSObject, ARSessionDelegate {
         
         Task { @MainActor in
             guard let arState = self.arState else { return }
-
+            
             // 🔥 값이 감소한 경우 무시
             if roundedArea < arState.recognizedArea { return }
-
+            
             if arState.recognizedArea != roundedArea {
                 arState.recognizedArea = roundedArea
             }
         }
+    }
+    
+    // MARK: - Game Flow Control
+
+    // 윷 결과 업데이트 후 -> 움직일 말 선택
+    func yutThrowCompleted(with result: YutResult) {
+        
+        guard let arState = self.arState else { return }
+        
+        // 1. GameManager에 윷 결과를 업데이트합니다.
+        arState.gameManager.yutResult = result
+        print("\(result)")
+        // 2. 이전에 있던 하이라이트를 모두 제거합니다.
+        self.pieceManager.clearAllHighlights()
+        
+        // 3. 다음 단계는 항상 '움직일 말 선택'이 됩니다.
+        DispatchQueue.main.async {
+            arState.gamePhase = .selectingPieceToMove
+        }
+    }
+    
+    // ✨ 턴을 종료하고 다음 플레이어를 준비시키는 헬퍼 함수
+    func endTurn() {
+        guard let arState = self.arState else { return }
+        let gameManager = arState.gameManager
+        
+        // 윷이나 모가 아니라면 다음 플레이어로 턴을 넘깁니다.
+        if gameManager.yutResult?.isExtraTurn == false {
+            gameManager.nextTurn()
+            print("턴 종료! 다음 플레이어: \(gameManager.currentPlayer.name)")
+        } else {
+            print("🎁 윷이나 모! 한 번 더 던지세요.")
+        }
+        
+        // 다시 윷을 던질 준비 상태로 돌아갑니다.
+        arState.gamePhase = .readyToThrow
     }
 }

--- a/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
+++ b/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
@@ -28,7 +28,6 @@ class ARCoordinator: NSObject, ARSessionDelegate {
     var planeManager: PlaneManager!
     var pieceManager: PieceManager!
     var yutManager: YutManager!
-    var gameLogicManager: GameLogicManager!
     var actionStreamHandler: ActionStreamHandler!
     
     // MARK: - 초기화
@@ -39,7 +38,6 @@ class ARCoordinator: NSObject, ARSessionDelegate {
         self.planeManager = PlaneManager(coordinator: self)
         self.pieceManager = PieceManager()
         self.yutManager = YutManager(coordinator: self)
-        self.gameLogicManager = GameLogicManager()
         self.gestureHandler = GestureHandler(coordinator: self)
         self.actionStreamHandler = ActionStreamHandler(coordinator: self)
     }

--- a/Yut/Yut/Features/ARGamePlay/Manager /ActionStreamHandler.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /ActionStreamHandler.swift
@@ -29,46 +29,59 @@ final class ActionStreamHandler {
             
         case .setupNewGame:
             Task {
-                // 1명 호스트, 3명 게스트 (총 4명) 더미 플레이어 생성
-                let playerSpecs: [(String, Int, Bool)] = [
-                    ("호스트", 0, true),
-                    ("게스트1", 1, false),
-                    ("게스트2", 2, false),
-                    ("게스트3", 3, false)
-                ]
-                let players: [PlayerModel] = await withTaskGroup(of: PlayerModel.self) { group in
-                    for (name, seq, isHost) in playerSpecs {
-                        // peerID의 displayName을 이름과 동일하게 둔다
-                        let peerID = MCPeerID(displayName: name)
-                        group.addTask {
-                            await PlayerModel.load(
-                                name: name,
-                                sequence: seq,
-                                peerID: peerID,
-                                isHost: isHost
-                            )
-                        }
-                    }
-                    var result: [PlayerModel] = []
-                    for await player in group {
-                        result.append(player)
-                    }
-                    // sequence 순으로 정렬
-                    return result.sorted { $0.sequence < $1.sequence }
-                }
-                coordinator.arState?.gameManager.startGame(with: players)
-                coordinator.pieceManager.boardAnchor = coordinator.boardManager.yutBoardAnchor
+                // 1. 실제 플레이어와 말 모델(Entity)들을 비동기로 로드합니다.
+                //    (PlayerModel에 만들어두신 load 함수를 활용)
+                //    peerID는 멀티플레이 구현 전이므로 임시값을 사용합니다.
                 
+                // Main 스레드에서 GameManager를 설정하고 게임 상태를 변경합니다.
                 await MainActor.run {
-                    coordinator.arState?.gamePhase = .readyToThrow
+                    let player1 = PlayerModel(name: "노랑", sequence: 1, peerID: MCPeerID(displayName: "Player1"))
+                    let player2 = PlayerModel(name: "초록", sequence: 2, peerID: MCPeerID(displayName: "Player2"))
+                    
+                    guard let arState = coordinator.arState,
+                          let boardManager = coordinator.boardManager,
+                          let pieceManager = coordinator.pieceManager
+                    else { return }
+                    
+                    // 2. GameManager에 실제 플레이어 정보로 새 게임을 설정합니다.
+                    arState.gameManager.startGame(with: [player1, player2])
+                    
+                    // 3. PieceManager가 윷판 앵커를 알 수 있도록 연결합니다.
+                    pieceManager.boardAnchor = boardManager.yutBoardAnchor
+                    
+                    // 4. 모든 준비가 끝났으니, 윷을 던질 준비 상태로 전환합니다.
+                    arState.gamePhase = .readyToThrow
                 }
             }
-//
-//        case .showDestinationsForNewPiece:
-//            handleShowDestinationsForNewPiece()
-//
-//        case .showDestinationsForExistingPiece:
-//            handleShowDestinationsForExistingPiece()
+            
+        case .showDestinationsForNewPiece:
+            guard let arState = coordinator.arState else { return }
+            let gameManager = arState.gameManager
+            
+            // 1. 현재 플레이어의 말 중 판 밖에 있는 첫 번째 말을 찾습니다.
+            guard let newPiece = gameManager.currentPlayer.pieces.first(where: { $0.position == "_6_6" }),
+                  let yutResult = gameManager.yutResult
+            else {
+                print("말이없어잉")
+                return
+            }
+            
+            // 2. 그 말의 목적지를 계산합니다.
+            let destinations = gameManager.routeOptions(for: newPiece, yutResult: yutResult, currentRouteIndex: newPiece.routeIndex)
+            
+            if !destinations.isEmpty {
+                // 3. 목적지 타일들을 하이라이트합니다.
+                let destinationNames = destinations.map { $0.destinationID }
+                coordinator.pieceManager.highlightTiles(named: destinationNames)
+                
+                // 4. '새 말'을 선택된 것으로 상태에 저장하고, '목적지 선택' 단계로 전환합니다.
+                arState.selectedPiece = newPiece
+                arState.availableDestinations = destinationNames
+                arState.gamePhase = .selectingDestination
+            }
+            //
+            //        case .showDestinationsForExistingPiece:
+            //            handleShowDestinationsForExistingPiece()
             
         case .startMonitoringMotion:
             coordinator.yutManager.startMonitoringMotion()
@@ -78,38 +91,38 @@ final class ActionStreamHandler {
         }
     }
     
-//    /// 새 말을 위한 목적지 계산 및 하이라이트 처리
-//    private func handleShowDestinationsForNewPiece() {
-//        coordinator.arState?.selectedPiece = nil
-//
-//        let positions = coordinator.gameLogicManager.getPossibleDestinations(
-//            for: nil,
-//            yutResult: 0
-//        )
-//
-//        coordinator.arState?.possibleDestinations = positions
-//        coordinator.pieceManager.highlightPositions(positions)
-//
-//        Task { @MainActor in
-//            coordinator.arState?.gamePhase = .selectingDestination
-//        }
-//    }
-//
-//    /// 기존 말을 위한 목적지 계산 및 하이라이트 처리
-//    private func handleShowDestinationsForExistingPiece() {
-//        guard let piece = coordinator.arState?.selectedPiece,
-//              let yutResult = coordinator.arState?.yutResult else { return }
-//
-//        let positions = coordinator.gameLogicManager.getPossibleDestinations(
-//            for: piece,
-//            yutResult: yutResult
-//        )
-//
-//        coordinator.arState?.possibleDestinations = positions
-//        coordinator.pieceManager.highlightPositions(positions)
-//
-//        Task { @MainActor in
-//            coordinator.arState?.gamePhase = .selectingDestination
-//        }
-//    }
+    //    /// 새 말을 위한 목적지 계산 및 하이라이트 처리
+    //    private func handleShowDestinationsForNewPiece() {
+    //        coordinator.arState?.selectedPiece = nil
+    //
+    //        let positions = coordinator.gameLogicManager.getPossibleDestinations(
+    //            for: nil,
+    //            yutResult: 0
+    //        )
+    //
+    //        coordinator.arState?.possibleDestinations = positions
+    //        coordinator.pieceManager.highlightPositions(positions)
+    //
+    //        Task { @MainActor in
+    //            coordinator.arState?.gamePhase = .selectingDestination
+    //        }
+    //    }
+    //
+    //    /// 기존 말을 위한 목적지 계산 및 하이라이트 처리
+    //    private func handleShowDestinationsForExistingPiece() {
+    //        guard let piece = coordinator.arState?.selectedPiece,
+    //              let yutResult = coordinator.arState?.yutResult else { return }
+    //
+    //        let positions = coordinator.gameLogicManager.getPossibleDestinations(
+    //            for: piece,
+    //            yutResult: yutResult
+    //        )
+    //
+    //        coordinator.arState?.possibleDestinations = positions
+    //        coordinator.pieceManager.highlightPositions(positions)
+    //
+    //        Task { @MainActor in
+    //            coordinator.arState?.gamePhase = .selectingDestination
+    //        }
+    //    }
 }

--- a/Yut/Yut/Features/ARGamePlay/Manager /ActionStreamHandler.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /ActionStreamHandler.swift
@@ -1,37 +1,75 @@
 /// ARCoordinator로부터 명령을 위임받아 처리하는 액션 핸들러
 import Combine
+import MultipeerConnectivity
 
 final class ActionStreamHandler {
     unowned let coordinator: ARCoordinator
     private var cancellables = Set<AnyCancellable>()
-
+    
     init(coordinator: ARCoordinator) {
         self.coordinator = coordinator
     }
     
     func subscribe(to arState: ARState) {
-            arState.actionStream
-                .sink { [weak self] action in
-                    self?.handle(action)
-                }
-                .store(in: &cancellables)
-        }
-
+        arState.actionStream
+            .sink { [weak self] action in
+                self?.handle(action)
+            }
+            .store(in: &cancellables)
+    }
+    
     /// 외부에서 호출되는 공용 처리 함수
     private func handle(_ action: ARAction) {
         switch action {
         case .fixBoardPosition:
             coordinator.boardManager.fixBoardPosition()
-
+            
         case .disablePlaneVisualization:
             coordinator.planeManager.disablePlaneVisualization()
-
-        case .showDestinationsForNewPiece:
-            handleShowDestinationsForNewPiece()
-
-        case .showDestinationsForExistingPiece:
-            handleShowDestinationsForExistingPiece()
-
+            
+        case .setupNewGame:
+            Task {
+                // 1명 호스트, 3명 게스트 (총 4명) 더미 플레이어 생성
+                let playerSpecs: [(String, Int, Bool)] = [
+                    ("호스트", 0, true),
+                    ("게스트1", 1, false),
+                    ("게스트2", 2, false),
+                    ("게스트3", 3, false)
+                ]
+                let players: [PlayerModel] = await withTaskGroup(of: PlayerModel.self) { group in
+                    for (name, seq, isHost) in playerSpecs {
+                        // peerID의 displayName을 이름과 동일하게 둔다
+                        let peerID = MCPeerID(displayName: name)
+                        group.addTask {
+                            await PlayerModel.load(
+                                name: name,
+                                sequence: seq,
+                                peerID: peerID,
+                                isHost: isHost
+                            )
+                        }
+                    }
+                    var result: [PlayerModel] = []
+                    for await player in group {
+                        result.append(player)
+                    }
+                    // sequence 순으로 정렬
+                    return result.sorted { $0.sequence < $1.sequence }
+                }
+                coordinator.arState?.gameManager.startGame(with: players)
+                coordinator.pieceManager.boardAnchor = coordinator.boardManager.yutBoardAnchor
+                
+                await MainActor.run {
+                    coordinator.arState?.gamePhase = .readyToThrow
+                }
+            }
+//
+//        case .showDestinationsForNewPiece:
+//            handleShowDestinationsForNewPiece()
+//
+//        case .showDestinationsForExistingPiece:
+//            handleShowDestinationsForExistingPiece()
+            
         case .startMonitoringMotion:
             coordinator.yutManager.startMonitoringMotion()
             Task { @MainActor in
@@ -39,39 +77,39 @@ final class ActionStreamHandler {
             }
         }
     }
-
-    /// 새 말을 위한 목적지 계산 및 하이라이트 처리
-    private func handleShowDestinationsForNewPiece() {
-        coordinator.arState?.selectedPiece = nil
-
-        let positions = coordinator.gameLogicManager.getPossibleDestinations(
-            for: nil,
-            yutResult: 0
-        )
-
-        coordinator.arState?.possibleDestinations = positions
-        coordinator.pieceManager.highlightPositions(positions)
-
-        Task { @MainActor in
-            coordinator.arState?.gamePhase = .selectingDestination
-        }
-    }
-
-    /// 기존 말을 위한 목적지 계산 및 하이라이트 처리
-    private func handleShowDestinationsForExistingPiece() {
-        guard let piece = coordinator.arState?.selectedPiece,
-              let yutResult = coordinator.arState?.yutResult else { return }
-
-        let positions = coordinator.gameLogicManager.getPossibleDestinations(
-            for: piece,
-            yutResult: yutResult
-        )
-
-        coordinator.arState?.possibleDestinations = positions
-        coordinator.pieceManager.highlightPositions(positions)
-
-        Task { @MainActor in
-            coordinator.arState?.gamePhase = .selectingDestination
-        }
-    }
+    
+//    /// 새 말을 위한 목적지 계산 및 하이라이트 처리
+//    private func handleShowDestinationsForNewPiece() {
+//        coordinator.arState?.selectedPiece = nil
+//
+//        let positions = coordinator.gameLogicManager.getPossibleDestinations(
+//            for: nil,
+//            yutResult: 0
+//        )
+//
+//        coordinator.arState?.possibleDestinations = positions
+//        coordinator.pieceManager.highlightPositions(positions)
+//
+//        Task { @MainActor in
+//            coordinator.arState?.gamePhase = .selectingDestination
+//        }
+//    }
+//
+//    /// 기존 말을 위한 목적지 계산 및 하이라이트 처리
+//    private func handleShowDestinationsForExistingPiece() {
+//        guard let piece = coordinator.arState?.selectedPiece,
+//              let yutResult = coordinator.arState?.yutResult else { return }
+//
+//        let positions = coordinator.gameLogicManager.getPossibleDestinations(
+//            for: piece,
+//            yutResult: yutResult
+//        )
+//
+//        coordinator.arState?.possibleDestinations = positions
+//        coordinator.pieceManager.highlightPositions(positions)
+//
+//        Task { @MainActor in
+//            coordinator.arState?.gamePhase = .selectingDestination
+//        }
+//    }
 }

--- a/Yut/Yut/Features/ARGamePlay/Manager /GestureHandler.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /GestureHandler.swift
@@ -51,45 +51,7 @@ class GestureHandler {
             }
             
         case .selectingPieceToMove:
-            //            guard let tappedEntity = arView.entity(at: tapLocation),
-            //                  // 탭한 것이 '말' 엔티티인지 확인 (관리 배열에 포함되어 있는지)
-            //                  let piece = contentManager.pieceEntities.first(where: { $0 == tappedEntity })
-            //            else { return }
-            //
-            //            arState.selectedPiece = piece
-            //            arState.actionStream.send(.showDestinationsForExistingPiece)
-            // --- 디버깅을 위해 로그를 추가한 '기존 말 선택' 로직 ---
-            
-            //            // 1. 탭한 위치에 어떤 엔티티가 있는지 확인합니다.
-            //            if let tappedEntity = arView.entity(at: tapLocation) {
-            //                print("--- 탭 감지 ---")
-            //                print("감지된 엔티티 이름: \(tappedEntity.name)")
-            //
-            //                // 2. 감지된 엔티티가 우리가 관리하는 '말' 중 하나인지 확인합니다.
-            //                // 탭 된 엔티티의 이름이 "yut_piece_"로 시작하는지 확인합니다.
-            //                let pieceName = tappedEntity.name
-            //                if pieceName
-            //                    .starts(with: "yut_piece_") {
-            //
-            //                    // 이름으로 관리 배열에서 해당 말을 찾습니다.
-            //                    if let piece = contentManager.pieceEntities.first(
-            //                        where: { $0.name == pieceName
-            //                        }) {
-            //                        print("성공: \(pieceName) 말을 탭했습니다.")
-            //
-            //                        // 기존 로직 실행
-            //                        arState.selectedPiece = piece
-            //                        arState.actionStream
-            //                            .send(.showDestinationsForExistingPiece)
-            //                    }
-            //                } else {
-            //                    print("탭한 엔티티(\(tappedEntity.name))는 말이 아닙니다.")
-            //                }
-            //
-            //            } else {
-            //                print("--- 탭 실패: 아무것도 감지되지 않았습니다. ---")
-            //                print("Collision Shape이 없거나, 너무 작거나, 다른 객체에 가려졌을 수 있습니다.")
-            //            }
+
             guard let tappedEntity = arView.entity(at: tapLocation) else {
                 print("탭 실패: 아무것도 감지되지 않았습니다.")
                 return
@@ -118,7 +80,7 @@ class GestureHandler {
                 
                 // 기존 로직 실행
                 arState.selectedPiece = piece
-                arState.actionStream.send(.showDestinationsForExistingPiece)
+                //mmarState.actionStream.send(.showDestinationsForExistingPiece)
                 
             } else {
                 print("실패: 탭한 엔티티(\(tappedEntity.name)) 또는 그 부모 중에 관리 중인 말이 없습니다.")

--- a/Yut/Yut/Features/ARGamePlay/Manager /PieceManager.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /PieceManager.swift
@@ -14,7 +14,7 @@ final class PieceManager {
     weak var boardAnchor: AnchorEntity? // 윷판 앵커
     var pieceEntities: [Entity] = []
     
-    private var originalMaterials: [String: RealityFoundation.Material] = [:]
+    private var originalMaterials: [ModelEntity: RealityFoundation.Material] = [:]
     
     
     func placeNewPiece(on tileName: String) {
@@ -68,45 +68,82 @@ final class PieceManager {
     
     // MARK: - Highlighting
     
-    func highlightPositions(_ names: [String]) {
+    // ✨ 1. 기존 함수를 '타일' 하이라이트 전용으로 이름을 명확하게 변경
+    func highlightTiles(named tileNames: [String]) {
         guard let boardEntity = boardAnchor?.children.first else {
             print("❌ 윷판 엔티티 없음")
             return
         }
         
-        clearHighlights()
+        clearAllHighlights() // 이전에 있던 모든 하이라이트 제거
         
-        for name in names {
-            guard let tile = boardEntity.findEntity(named: name) as? ModelEntity else {
-                print("❌ 타일 \(name) 없음")
-                continue
-            }
-            
-            if let material = tile.model?.materials.first {
-                originalMaterials[name] = material
-            }
-            
-            var highlightMaterial = UnlitMaterial()
-            highlightMaterial.color = .init(tint: .yellow.withAlphaComponent(0.8))
-            
-            if var model = tile.model {
-                model.materials = [highlightMaterial]
-                tile.model = model
-            }
+        for name in tileNames {
+            guard let tile = boardEntity.findEntity(named: name) as? ModelEntity else { continue }
+            applyHighlight(to: tile)
         }
     }
     
-    func clearHighlights() {
-        guard let boardEntity = boardAnchor?.children.first else { return }
+    // ✨ 2. 제안하신 '말'들을 하이라이트하는 새로운 함수
+    func highlightMovablePieces(_ pieces: [PieceModel]) {
+        clearAllHighlights() // 이전에 있던 모든 하이라이트 제거
         
-        for (name, original) in originalMaterials {
-            if let tile = boardEntity.findEntity(named: name) as? ModelEntity,
-               var model = tile.model {
-                model.materials = [original]
-                tile.model = model
-            }
+        for piece in pieces {
+            // PieceModel에서 AR Entity를 직접 가져옵니다.
+            guard let pieceEntity = piece.entity as? ModelEntity else { continue }
+            applyHighlight(to: pieceEntity)
+        }
+    }
+    
+    
+    // ✨ 3. 하이라이트를 적용하는 로직을 별도 함수로 분리 (코드 중복 제거)
+    private func applyHighlight(to entity: ModelEntity) {
+        guard let model = entity.model else { return }
+        
+        // 원래 머티리얼을 딕셔너리에 저장
+        if let material = model.materials.first {
+            originalMaterials[entity] = material
         }
         
+        // 하이라이트 머티리얼 생성 및 적용
+        var highlightMaterial = UnlitMaterial()
+        highlightMaterial.color = .init(tint: .yellow.withAlphaComponent(0.8))
+        
+        var newModel = model
+        newModel.materials = [highlightMaterial]
+        entity.model = newModel
+    }
+    
+    // ✨ 4. 모든 하이라이트를 원래대로 되돌리는 함수
+    func clearAllHighlights() {
+        // 딕셔너리에 저장된 모든 엔티티를 순회하며 원래 머티리얼로 복원
+        for (entity, originalMaterial) in originalMaterials {
+            entity.model?.materials = [originalMaterial]
+        }
         originalMaterials.removeAll()
     }
+    
+    // ✨ 판 밖에 있던 말을 처음으로 AR 씬에 추가하는 함수
+        func placePieceOnBoard(piece: PieceModel, on tileName: String) {
+            guard let destinationTile = boardAnchor?.findEntity(named: tileName) else {
+                print("❌ 목적지 \(tileName) 타일을 찾을 수 없습니다.")
+                return
+            }
+            
+            
+        
+            
+            
+            
+            
+            let pieceEntity = piece.entity // PlayerModel.load()가 이미 로드해 둔 엔티티
+            
+            pieceEntity.generateCollisionShapes(recursive: true)
+            pieceEntity.scale = [0.3, 8.0, 0.3]
+            pieceEntity.position = [0, 0.2, 0]
+            
+            destinationTile.addChild(pieceEntity)
+
+            
+            print("✅ \(piece.entity.name)을 \(tileName)에 처음으로 배치했습니다.")
+        }
 }

--- a/Yut/Yut/Features/ARGamePlay/Manager /YutManager.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /YutManager.swift
@@ -54,6 +54,17 @@ final class YutManager {
     
     func throwYuts() {
         guard let arView = arView else { return }
+        // 기존 윷 제거
+            
+            // 1. 씬(Scene)에서 이전에 던져진 윷 엔티티들을 제거합니다.
+            for yutModel in thrownYuts {
+                // 각 윷(ModelEntity)은 AnchorEntity의 자식으로 추가되었으므로,
+                // 부모 앵커를 찾아서 씬에서 제거해야 합니다.
+                yutModel.entity.parent?.removeFromParent()
+            }
+            
+            // 2. 다음 계산을 위해 윷 모델을 추적하는 배열을 비웁니다.
+            thrownYuts.removeAll()
         
         let yutNames = ["Yut1", "Yut2", "Yut3", "Yut4_back"]
         let spacing: Float = 0.07
@@ -130,6 +141,7 @@ final class YutManager {
             if allStopped {
                 timer.invalidate()
                 self.evaluateYuts()
+
             }
         }
     }
@@ -170,5 +182,8 @@ final class YutManager {
         if result.isExtraTurn {
             print("🎁 추가 턴!")
         }
+        
+        // Coordinator 연결
+        coordinator.yutThrowCompleted(with: result)
     }
 }

--- a/Yut/Yut/Features/ARGamePlay/PlayView.swift
+++ b/Yut/Yut/Features/ARGamePlay/PlayView.swift
@@ -53,7 +53,7 @@ struct PlayView : View {
                     EmptyView() // 상단 안내 없음
                     Spacer()
                     RoundedBrownButton(title: "윷놀이 시작!", isEnabled: true) {
-                        arState.gamePhase = .readyToThrow
+                        arState.actionStream.send(.setupNewGame)
                     }
 
                 // 5. 윷 던지기 준비 단계
@@ -85,9 +85,9 @@ struct PlayView : View {
                         }
 
                         // 새 말 놓기 버튼
-                        RoundedBrownButton(title: "새 말 놓기", isEnabled: true) {
-                            arState.actionStream.send(.showDestinationsForNewPiece)
-                        }
+//                        RoundedBrownButton(title: "새 말 놓기", isEnabled: true) {
+//                            arState.actionStream.send(.showDestinationsForNewPiece)
+//                        }
                     }
 
                 // 7. 말의 이동 목적지 선택 단계

--- a/Yut/Yut/Features/ARGamePlay/PlayView.swift
+++ b/Yut/Yut/Features/ARGamePlay/PlayView.swift
@@ -16,7 +16,7 @@ struct PlayView : View {
                 // 게임 상태에 따라 상단 안내 뷰 + 하단 인터랙션 UI를 함께 표시
                 switch arState.gamePhase {
                     
-                // 1. 바닥 탐색 중 (아직 충분히 인식되지 않음)
+                    // 1. 바닥 탐색 중 (아직 충분히 인식되지 않음)
                 case .searchingForSurface:
                     ProgressBar(
                         text: "바닥을 충분히 색칠해 주세요.",
@@ -31,13 +31,13 @@ struct PlayView : View {
                         }
                     }
                     
-                // 2. 사용자가 탭으로 보드를 놓는 단계
+                    // 2. 사용자가 탭으로 보드를 놓는 단계
                 case .placeBoard:
                     InstructionView(text: "탭해서 말판을 배치하세요.")
                     Spacer()
                     EmptyView() // 버튼 없음
-
-                // 3. 핀치/드래그로 위치/크기 조정 단계
+                    
+                    // 3. 핀치/드래그로 위치/크기 조정 단계
                 case .adjustingBoard:
                     InstructionView(text: "핀치와 드래그로\n보드의 크기와 위치를 조정하세요.")
                     Spacer()
@@ -47,50 +47,38 @@ struct PlayView : View {
                         arState.actionStream.send(.disablePlaneVisualization)
                         arState.gamePhase = .boardConfirmed
                     }
-
-                // 4. 보드가 확정된 상태 (게임 시작 대기)
+                    
+                    // 4. 보드가 확정된 상태 (게임 시작 대기)
                 case .boardConfirmed:
                     EmptyView() // 상단 안내 없음
                     Spacer()
                     RoundedBrownButton(title: "윷놀이 시작!", isEnabled: true) {
                         arState.actionStream.send(.setupNewGame)
                     }
-
-                // 5. 윷 던지기 준비 단계
+                    
+                    // 5. 윷 던지기 준비 단계
                 case .readyToThrow:
                     InstructionView(text: "버튼을 눌러 윷을 던져랏")
                     Spacer()
                     RoundedBrownButton(title: "윷 던지기 활성화!", isEnabled: true) {
                         arState.actionStream.send(.startMonitoringMotion)
                     }
-
-                // 6. 움직일 말 선택 단계
+                    
+                    // 6. 움직일 말 선택 단계
                 case .selectingPieceToMove:
                     VStack {
-                        InstructionView(text: "움직일 말을 선택하세요.")
+                        InstructionView(text: "\(arState.gameManager.currentPlayer.name)의 턴: 움직일 말을 탭하세요.")
                         Spacer()
-                        InstructionView(text: "움직일 말을 탭하세요.")
-                        
-                        // 도/개/걸/윷/모 결과 수동 선택
-                        HStack {
-                            ForEach(1 ..< 6) { i in
-                                Button("\(i)칸") {
-                                    arState.yutResult = i
-                                }
-                                .padding()
-                                .background(arState.yutResult == i ? Color.yellow : Color.brown)
-                                .foregroundColor(.white)
-                                .cornerRadius(8)
+
+                        // 만약 현재 플레이어가 판 밖에 둔 말이 있다면, '새 말 놓기' 버튼을 보여줍니다.
+                        if arState.gameManager.currentPlayerHasOffBoardPieces {
+                            RoundedBrownButton(title: "새 말 놓기", isEnabled: true) {
+                                arState.actionStream.send(.showDestinationsForNewPiece)
                             }
                         }
-
-                        // 새 말 놓기 버튼
-//                        RoundedBrownButton(title: "새 말 놓기", isEnabled: true) {
-//                            arState.actionStream.send(.showDestinationsForNewPiece)
-//                        }
                     }
-
-                // 7. 말의 이동 목적지 선택 단계
+                    
+                    // 7. 말의 이동 목적지 선택 단계
                 case .selectingDestination:
                     InstructionView(text: "말을 옮길 곳을 선택하세요.")
                     Spacer()

--- a/Yut/Yut/Features/ARGamePlay/State/ARState.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/ARState.swift
@@ -10,6 +10,9 @@ class ARState: ObservableObject {
 
     // Coordinator와 통신할 명령 스트림
     let actionStream = PassthroughSubject<ARAction, Never>()
+    
+    // GameManager 싱글톤 인스턴스
+    @ObservedObject var gameManager = GameManager.shared
 
     // 바닥 인식 면적 관련
     @Published var recognizedArea: Float = 0.0
@@ -21,4 +24,5 @@ class ARState: ObservableObject {
 
     // 윷 결과 (도:1 ~ 모:5)
     @Published var yutResult: Int = 1
+
 }

--- a/Yut/Yut/Features/ARGamePlay/State/ARState.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/ARState.swift
@@ -19,8 +19,8 @@ class ARState: ObservableObject {
     let minRequiredArea: Float = 15.0
 
     // 말 선택 및 이동 후보 위치
-    @Published var selectedPiece: Entity? = nil
-    @Published var possibleDestinations: [String] = []
+    @Published var selectedPiece: PieceModel? = nil
+    @Published var availableDestinations: [String] = []
 
     // 윷 결과 (도:1 ~ 모:5)
     @Published var yutResult: Int = 1

--- a/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
@@ -3,7 +3,8 @@
 enum ARAction {
     case fixBoardPosition                // 윷판을 평면 위에 고정
     case disablePlaneVisualization      // 평면 시각화 비활성화
-    case showDestinationsForNewPiece    // 새 말 놓을 위치 하이라이트
-    case showDestinationsForExistingPiece // 기존 말 이동 가능 위치 하이라이트
+    case setupNewGame                   // 게임 시작
+//    case showDestinationsForNewPiece    // 새 말 놓을 위치 하이라이트
+//    case showDestinationsForExistingPiece // 기존 말 이동 가능 위치 하이라이트
     case startMonitoringMotion          // 윷 던지기 감지 시작 (CoreMotion)
 }

--- a/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
@@ -4,7 +4,7 @@ enum ARAction {
     case fixBoardPosition                // 윷판을 평면 위에 고정
     case disablePlaneVisualization      // 평면 시각화 비활성화
     case setupNewGame                   // 게임 시작
-//    case showDestinationsForNewPiece    // 새 말 놓을 위치 하이라이트
+    case showDestinationsForNewPiece    // ✨ '새 말'의 경로를 보여달라는 명확한 액션
 //    case showDestinationsForExistingPiece // 기존 말 이동 가능 위치 하이라이트
     case startMonitoringMotion          // 윷 던지기 감지 시작 (CoreMotion)
 }

--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -36,7 +36,7 @@ class GameManager :ObservableObject {
     static let shared = GameManager() // singleton
     
     // 플레이어 프로퍼티
-    let players: [PlayerModel] // 플레이어 받아오기
+    @Published var players: [PlayerModel] = [] // 플레이어 받아오기
     var currentPlayerIndex: Int = 0 // 현재 플레이어 인덱스
     var currentPlayer: PlayerModel { // 현재 플레이어
         players[currentPlayerIndex]
@@ -52,7 +52,8 @@ class GameManager :ObservableObject {
     @Published var result: GameResult? // 게임 최종 결과 반환
     @State private var userChooseToCarry: Bool = false // 업을지 말지 여부 상태 변수
     
-    func startGame() {
+    func startGame(with players: [PlayerModel]) {
+        self.players = players
         currentPlayerIndex = 0
         yutResult = nil
         cellStates = [:] // 모든 칸에 있는 말 비우기

--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -52,6 +52,13 @@ class GameManager :ObservableObject {
     @Published var result: GameResult? // 게임 최종 결과 반환
     @State private var userChooseToCarry: Bool = false // 업을지 말지 여부 상태 변수
     
+    // ✨ 현재 플레이어가 판 밖에 둔 말이 있는지 확인하는 프로퍼티 추가
+        var currentPlayerHasOffBoardPieces: Bool {
+            // currentPlayer의 말 중에 position이 "_6_6"인 것이 하나라도 있는지 확인
+            currentPlayer.pieces.contains { $0.position == "_6_6" }
+        }
+
+    
     func startGame(with players: [PlayerModel]) {
         self.players = players
         currentPlayerIndex = 0
@@ -59,9 +66,11 @@ class GameManager :ObservableObject {
         cellStates = [:] // 모든 칸에 있는 말 비우기
         
         for piece in pieces {
-            piece.position = "_6_6"
+            piece.position = "_6_6" // PieceModel의 기본값이지만 명시적으로 설정
             piece.isSelected = false
+            piece.routeIndex = 0 // 기본 경로로 설정
         }
+        print("✅ GameManager: 새로운 게임이 \(players.count)명의 플레이어와 함께 설정되었습니다.")
     }
     
     func selectPiece(by id: UUID) { // 이건 UI 단에서 선택되는 id를 반환해야 정해질 것 같음(?) 그 UUID를 기준으로 isSelected가 true로 바뀌는 것
@@ -74,7 +83,7 @@ class GameManager :ObservableObject {
         let currentID = piece.position
         let possibleRoutes = board.availableRouteIndicate(at: currentID, currentRoute: currentRouteIndex)
         var options: [(Int, String)] = []
-
+        
         for routeIndex in possibleRoutes {
             let route = board.routes[routeIndex]
             if let currentIndex = route.firstIndex(of: currentID) {
@@ -87,6 +96,7 @@ class GameManager :ObservableObject {
         }
         return options
     }
+    
     
     // 경로 인덱스와 몇 칸 이동하는지 입력 받으면 그에 맞는 경로 결과 반환
     func move(piece: PieceModel, to targetCellID: String) {
@@ -104,9 +114,9 @@ class GameManager :ObservableObject {
                 gameEnded: true
             )
         }
-
+        
         let existingPieces = cellStates[targetCellID] ?? []
-
+        
         if existingPieces.isEmpty {
             cellStates[targetCellID] = [piece]
             return GameResult(
@@ -117,7 +127,7 @@ class GameManager :ObservableObject {
                 gameEnded: false
             )
         }
-
+        
         let existingOwner = existingPieces.first!.owner
         if existingOwner === piece.owner && userChooseToCarry == true {
             // 업기
@@ -168,28 +178,28 @@ class GameManager :ObservableObject {
         // Result의 gameEnded가 true이면 게임 종료 -> 게임 결과 화면 띄우고,
     }
     
-    init() {
-        // TESTONLY
-        let dummyEntity1 = Entity()
-        let dummyEntity2 = Entity()
-
-        let player1 = PlayerModel(
-            name: "Player 1",
-            sequence: 0,
-            peerID: MCPeerID(displayName: UUID().uuidString),
-            entities: [dummyEntity1, dummyEntity2]
-        )
-
-        let player2 = PlayerModel(
-            name: "Player 2",
-            sequence: 1,
-            peerID: MCPeerID(displayName: UUID().uuidString),
-            entities: [dummyEntity1, dummyEntity2]
-        )
-        self.players = [player1, player2]
-        self.board = BoardModel()
-        self.cellStates = [:]
-        self.yutResult = nil
-    }
+//    init() {
+//        // TESTONLY
+//        let dummyEntity1 = Entity()
+//        let dummyEntity2 = Entity()
+//        
+//        let player1 = PlayerModel(
+//            name: "Player 1",
+//            sequence: 0,
+//            peerID: MCPeerID(displayName: UUID().uuidString),
+////            entities: [dummyEntity1, dummyEntity2]
+//        )
+//        
+//        let player2 = PlayerModel(
+//            name: "Player 2",
+//            sequence: 1,
+//            peerID: MCPeerID(displayName: UUID().uuidString),
+////            entities: [dummyEntity1, dummyEntity2]
+//        )
+//        self.players = [player1, player2]
+//        self.board = BoardModel()
+//        self.cellStates = [:]
+//        self.yutResult = nil
+//    }
 }
 

--- a/Yut/Yut/Features/Lobby/Models/PieceModel.swift
+++ b/Yut/Yut/Features/Lobby/Models/PieceModel.swift
@@ -15,10 +15,17 @@ class PieceModel {
     var routeIndex: Int = 0
     var isSelected: Bool = false
 
-    init(owner: PlayerModel, entity: Entity, position: String = "_6_6") {
+    // 모델 로딩에 실패하면 객체 생성 자체를 실패
+    init?(owner: PlayerModel, position: String = "_6_6") {
         self.owner = owner
-        self.entity = entity
         self.position = position
+        do {
+            let tokenEntity: Entity = try ModelEntity.load(named: owner.pieceEntity)
+            self.entity = tokenEntity
+        } catch {
+            print("모델 로딩 실패: \(error)")
+            return nil
+        }
     }
 }
 

--- a/Yut/Yut/Features/Lobby/Models/PlayerModel.swift
+++ b/Yut/Yut/Features/Lobby/Models/PlayerModel.swift
@@ -16,7 +16,7 @@ class PlayerModel: Identifiable, ObservableObject, Codable, Equatable, Hashable 
     @Published var isHost: Bool
 
     var pieces: [PieceModel] = []
-    var pieceEntities: [Entity] = []
+//    var pieceEntities: [Entity] = []
     
     static let fileNames = ["Piece1_yellow", "Piece2_jade", "Piece3_blue", "Piece4_red"]
 
@@ -24,26 +24,42 @@ class PlayerModel: Identifiable, ObservableObject, Codable, Equatable, Hashable 
     var profile: String { "Player/P\(sequence)/profile" }
     var buttonOn: String { "Player/P\(sequence)/button_on" }
     var buttonOff: String { "Player/P\(sequence)/button_off" }
+    var pieceEntity: String {
+        switch sequence {
+        case 1:
+            return "Piece1_yellow"
+        case 2:
+            return "Piece2_jade"
+        case 3:
+            return "Piece3_blue"
+        case 4:
+            return "Piece4_red"
+        default:
+            fatalError("Invalid player sequence: \(sequence)")
+        }
+        
+        /*"Player/P\(sequence)/token"*/
+    }
 
     enum CodingKeys: String, CodingKey {
         case id, name, sequence, isHost, peerDisplayName
     }
 
-    init(name: String, sequence: Int, peerID: MCPeerID, entities: [Entity], isHost: Bool = false) {
+    init(name: String, sequence: Int, peerID: MCPeerID, isHost: Bool = false) {
         self.id = UUID()
         self.name = name
         self.sequence = sequence
         self.peerID = peerID
         self.isHost = isHost
-        //        self.pieceEntities = entities
-
-                let dummyEntities = Array(repeating: Entity(), count: 4)
-                self.pieceEntities = dummyEntities
+//        self.pieceEntities = entities
+//
+//                let dummyEntities = Array(repeating: Entity(), count: 4)
+//                self.pieceEntities = dummyEntities
                 
 
-        for i in 0..<2 {
-            //            let piece = PieceModel(owner: self, entity: entities[i])
-            let piece = PieceModel(owner: self, entity: dummyEntities[i])
+        for _ in 0..<2 {
+            guard let piece = PieceModel(owner: self) else { return }
+//            let piece = PieceModel(owner: self, entity: dummyEntities[i])
             pieces.append(piece)
         }
     }
@@ -58,7 +74,7 @@ class PlayerModel: Identifiable, ObservableObject, Codable, Equatable, Hashable 
 
             // Entity 임의로 주입
             let dummyEntities = Array(repeating: Entity(), count: 4)
-            self.init(name: name, sequence: sequence, peerID: MCPeerID(displayName: peerDisplayName), entities: dummyEntities, isHost: isHost)
+            self.init(name: name, sequence: sequence, peerID: MCPeerID(displayName: peerDisplayName), isHost: isHost)
         }
 
     func encode(to encoder: Encoder) throws {
@@ -79,17 +95,17 @@ class PlayerModel: Identifiable, ObservableObject, Codable, Equatable, Hashable 
     }
 
     static func load(name: String, sequence: Int, peerID: MCPeerID, isHost: Bool = false) async -> PlayerModel {
-        var loadedEntities: [Entity] = []
+//        var loadedEntities: [Entity] = []
 
-        for file in fileNames {
-            do {
-                let entity = try await Entity(named: file)
-                loadedEntities.append(entity)
-            } catch {
-                print("'\(file)' 로딩 실패:", error)
-            }
-        }
+//        for file in fileNames {
+//            do {
+//                let entity = try await Entity(named: file)
+//                loadedEntities.append(entity)
+//            } catch {
+//                print("'\(file)' 로딩 실패:", error)
+//            }
+//        }
 
-        return PlayerModel(name: name, sequence: sequence, peerID: peerID, entities: loadedEntities, isHost: isHost)
+        return PlayerModel(name: name, sequence: sequence, peerID: peerID, isHost: isHost)
     }
 }

--- a/Yut/Yut/Features/Lobby/Multipeer/MPCManager.swift
+++ b/Yut/Yut/Features/Lobby/Multipeer/MPCManager.swift
@@ -33,7 +33,7 @@ class MPCManager: NSObject, ObservableObject {
             name: name,
             sequence: 1,
             peerID: myPeerID,
-            entities: [],
+//            entities: [],
             isHost: true
         )
         players.append(hostPlayer)
@@ -58,7 +58,7 @@ class MPCManager: NSObject, ObservableObject {
             name: peerID.displayName,
             sequence: players.count + 1,
             peerID: peerID,
-            entities: []
+//            entities: []
         )
         players.append(guestPlayer)
         print("✅ Guest added: \(guestPlayer.name), sequence: \(guestPlayer.sequence), profile: \(guestPlayer.profile)")

--- a/Yut/Yut/Features/Lobby/Multipeer/MPCManager_Session.swift
+++ b/Yut/Yut/Features/Lobby/Multipeer/MPCManager_Session.swift
@@ -21,7 +21,7 @@ extension MPCManager: MCSessionDelegate {
                             name: peerID.displayName,
                             sequence: self.players.count + 1,
                             peerID: peerID,
-                            entities: [],
+//                            entities: [],
                             isHost: false
                         )
                         self.players.append(guestPlayer)


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->
- PlayerModel 내에서 Entity 제거 -> PieceModel 로 로직 이동
- ARState 내에서 GameManager 싱글톤 인스턴스 소유함으로써 뷰 - 데이터 분리
- GestureHandler 에서 탭 제스쳐 케이스에 따라 분리
    - selectingPieceToMove (탭한 말이 갈 수 있는 경로 하이라이트 후 이동)
    - selectingDestination (탭한 타일로 이동)
    ->> 아직 완벽하지 않음 윷 결과 띄워주는 UI 연결 후 재구현 할 예정.... 따라서 코드가 매우 더럽다
 

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: Closes #123
-->
>>#106 아직 클로즈 못함

## 테스트 방법 (How to Test)
<!--
변경 사항이 적용되었는지 테스트하기 위해 수행해야 하는 단계를 설명해주세요.
1. Go to '...'
2. Click on '...'
3. Observe '...'
-->

https://github.com/user-attachments/assets/0b8aa3e5-6d66-4bd6-9983-692b776b29fa


영상 참고해주세요 윷 먼저 던지고 결과 확정 후에 새 말 놓기 눌러야 오류가 안남

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->
윷 결과화면 연결해 주시면 다시 코드 정리 + 안되는 부분 마저 구현해서 깔끔예쁜PR 올리게씁니다 흑흑