### PR TITLE
fix: MPCManager 쉼표 오류 해결

### DIFF
--- a/Yut/Yut/Features/Lobby/Multipeer/MPCManager.swift
+++ b/Yut/Yut/Features/Lobby/Multipeer/MPCManager.swift
@@ -57,7 +57,7 @@ class MPCManager: NSObject, ObservableObject {
         let guestPlayer = PlayerModel(
             name: peerID.displayName,
             sequence: players.count + 1,
-            peerID: peerID,
+            peerID: peerID
 //            entities: []
         )
         players.append(guestPlayer)


### PR DESCRIPTION
<img width="457" height="200" alt="스크린샷 2025-07-28 21 53 21" src="https://github.com/user-attachments/assets/ac73073d-e61d-4741-84a0-75d5269650fb" />

peerID 뒤에 쉼표 없어야하는데 있길래 지웠습니다