### PR TITLE
fix: 자잘한 디테일 수정

### DIFF
--- a/Yut/Yut/Features/Lobby/Views/HomeView.swift
+++ b/Yut/Yut/Features/Lobby/Views/HomeView.swift
@@ -16,7 +16,7 @@ struct HomeView: View {
                 Text("윷")
                     .foregroundColor(.brown1)
                     .font(.hancom(.hoonmin, size: 236))
-                    .padding(.top, 50)
+                    .padding(.top, 98)
                 Spacer()
                 
                 VStack(spacing: 12) {

--- a/Yut/Yut/UIComponents/UIViewButton.swift
+++ b/Yut/Yut/UIComponents/UIViewButton.swift
@@ -35,10 +35,10 @@ struct UIViewButton: View {
                 
                 Text(title)
                     .foregroundColor(.brown2)
-                    .font(.system(size: 22, weight: .bold, design: .default))
+                    .font(.system(size: 20, weight: .bold, design: .default))
             }
             .frame(maxWidth: .infinity)
-            .frame(height: 75)
+            .frame(height: 65)
         }
         .disabled(!isEnabled)
     }


### PR DESCRIPTION
<img width="729" height="1020" alt="스크린샷 2025-07-29 01 47 51" src="https://github.com/user-attachments/assets/3fca13d2-e17b-4aae-9248-081922245bd8" />

노터 마음에 들도록 윷 패딩값이랑 버튼의 높이를 수정했읍니다