### PR TITLE
feat: 윷 던지기 결과 컴포넌트 연결

### DIFF
--- a/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
+++ b/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
@@ -90,9 +90,13 @@ class ARCoordinator: NSObject, ARSessionDelegate {
         // 2. 이전에 있던 하이라이트를 모두 제거합니다.
         self.pieceManager.clearAllHighlights()
         
-        // 3. 다음 단계는 항상 '움직일 말 선택'이 됩니다.
+        // 3. 다음 단계는 '윷 던지기 결과 표시' 3초 후 '움직일 말 선택'이 됩니다.
         DispatchQueue.main.async {
-            arState.gamePhase = .selectingPieceToMove
+            arState.gamePhase = .showingYutResult
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                arState.gamePhase = .selectingPieceToMove
+            }
         }
     }
     

--- a/Yut/Yut/Features/ARGamePlay/Manager /YutManager.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /YutManager.swift
@@ -162,7 +162,6 @@ final class YutManager {
             if allStopped {
                 timer.invalidate()
                 self.evaluateYuts()
-
             }
         }
     }
@@ -202,6 +201,12 @@ final class YutManager {
         print("🎯 윷 결과: \(result) (\(result.steps)칸 이동)")
         if result.isExtraTurn {
             print("🎁 추가 턴!")
+        }
+        
+        DispatchQueue.main.async {
+            print("[DEBUG] Setting to .showingYutResult")
+            self.arState?.yutResult = result
+            self.arState?.gamePhase = .showingYutResult
         }
         
         // Coordinator 연결

--- a/Yut/Yut/Features/ARGamePlay/State/ARState.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/ARState.swift
@@ -23,6 +23,7 @@ class ARState: ObservableObject {
     @Published var availableDestinations: [String] = []
 
     // 윷 결과 (도:1 ~ 모:5)
-    @Published var yutResult: Int = 1
+//    @Published var yutResult: Int = 1
+    @Published var yutResult: YutResult? = nil
 
 }

--- a/Yut/Yut/Features/ARGamePlay/State/Enums/GamePhase.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/Enums/GamePhase.swift
@@ -10,6 +10,7 @@ enum GamePhase {
     
     // 게임 진행 단계
     case readyToThrow               // 5단계: 윷 던지기 준비
+    case showingYutResult           // 5.5단계: 윷 던지기 결과 표시
     case selectingPieceToMove       // 6단계: 말을 선택하는 중
     case selectingDestination       // 7단계: 말의 이동 위치 선택
     // case pieceMoved              // (예정) 8단계: 말 이동 완료

--- a/Yut/Yut/UIComponents/RoundedBrownButton.swift
+++ b/Yut/Yut/UIComponents/RoundedBrownButton.swift
@@ -30,7 +30,13 @@ struct RoundedBrownButton: View {
                 )
                 .cornerRadius(24) // 모서리 둥글게
         }
-        .padding(.horizontal, 30) // 좌우 여백
+        .padding(.horizontal, 20) // 좌우 여백
         .disabled(!isEnabled) // 버튼 비활성화 처리
+    }
+}
+
+#Preview {
+    RoundedBrownButton(title: "sdf", isEnabled: true) {
+        
     }
 }


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->
<img width="350" alt="IMG_0178" src="https://github.com/user-attachments/assets/8d3fe418-1528-498a-a9a3-936d1021353a" />

콘솔에만 출력되던 윷 던지기 결과를 UI에 띄웁니다..

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: Closes #123
-->
Closes #110 

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->
결과는 3초 표시되었다가 사라집니다. 시간은 나중에 1.5초 정도로 줄여도 좋을 것 같아욥
윷 모이는 영상을 넣으려다가 실패해서 코드가 지저분한데 흑흑 나중에 말끔히 처리할게요
