### PR TITLE
Feat: 윷 결과에 따른 말 이동 구현 (위치 선택, 이동 애니메이션)

### DIFF
--- a/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
+++ b/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
@@ -1,6 +1,7 @@
 import ARKit
 import RealityKit
 import Combine
+import MultipeerConnectivity
 
 /// ARView의 이벤트를 처리하고 SwiftUI 상태와 연결해주는 총괄 Coordinator
 class ARCoordinator: NSObject, ARSessionDelegate {
@@ -78,7 +79,55 @@ class ARCoordinator: NSObject, ARSessionDelegate {
     }
     
     // MARK: - Game Flow Control
-
+    
+    // '새 게임 준비' 액션을 처리하는 함수
+    func setupNewGame() {
+        Task {
+            // Main 스레드
+            // GameManager 설정, 게임 상태 변경
+            
+            await MainActor.run {
+                // PlayerModel 로드 (PeerID 임시값)
+                let player1 = PlayerModel(name: "노랑", sequence: 1, peerID: MCPeerID(displayName: "Player1"))
+                let player2 = PlayerModel(name: "초록", sequence: 2, peerID: MCPeerID(displayName: "Player2"))
+                
+                guard let arState = self.arState else { return }
+                
+                // GameManager에 실제 플레이어 정보로 새 게임을 설정
+                arState.gameManager.startGame(with: [player1, player2])
+                
+                // PieceManager 윷판 앵커를 알 수 있도록 연결
+                self.pieceManager.boardAnchor = self.boardManager.yutBoardAnchor
+                
+                // 준비 끝, 상태 전환
+                arState.gamePhase = .readyToThrow
+            }
+        }
+    }
+    
+    // 새 말 놓을 때
+    func showDestinationsForNewPiece() {
+        guard let arState = self.arState else { return }
+        let gameManager = arState.gameManager
+        
+        // 시작점에 있는 말과, 윷 결과 게임매니저로부터 가져오기
+        guard let newPiece = gameManager.currentPlayer.pieces.first(where: { $0.position == "_6_6" }),
+              let yutResult = gameManager.yutResult
+        else { return }
+        
+        let destinations = gameManager.routeOptions(for: newPiece, yutResult: yutResult, currentRouteIndex: newPiece.routeIndex)
+        
+        // 목적지 타일 하이라이트
+        if !destinations.isEmpty {
+            let destinationNames = destinations.map { $0.destinationID }
+            self.pieceManager.highlightTiles(named: destinationNames)
+            
+            arState.selectedPiece = newPiece
+            arState.availableDestinations = destinationNames
+            arState.gamePhase = .selectingDestination
+        }
+    }
+    
     // 윷 결과 업데이트 후 -> 움직일 말 선택
     func yutThrowCompleted(with result: YutResult) {
         

--- a/Yut/Yut/Features/ARGamePlay/Manager /ActionStreamHandler.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /ActionStreamHandler.swift
@@ -18,7 +18,7 @@ final class ActionStreamHandler {
             .store(in: &cancellables)
     }
     
-    /// 외부에서 호출되는 공용 처리 함수
+    // 외부에서 호출되는 공용 처리 함수
     private func handle(_ action: ARAction) {
         switch action {
         case .fixBoardPosition:
@@ -28,67 +28,25 @@ final class ActionStreamHandler {
             coordinator.planeManager.disablePlaneVisualization()
             
         case .setupNewGame:
-            Task {
-                // 1. 실제 플레이어와 말 모델(Entity)들을 비동기로 로드합니다.
-                //    (PlayerModel에 만들어두신 load 함수를 활용)
-                //    peerID는 멀티플레이 구현 전이므로 임시값을 사용합니다.
-                
-                // Main 스레드에서 GameManager를 설정하고 게임 상태를 변경합니다.
-                await MainActor.run {
-                    let player1 = PlayerModel(name: "노랑", sequence: 1, peerID: MCPeerID(displayName: "Player1"))
-                    let player2 = PlayerModel(name: "초록", sequence: 2, peerID: MCPeerID(displayName: "Player2"))
-                    
-                    guard let arState = coordinator.arState,
-                          let boardManager = coordinator.boardManager,
-                          let pieceManager = coordinator.pieceManager
-                    else { return }
-                    
-                    // 2. GameManager에 실제 플레이어 정보로 새 게임을 설정합니다.
-                    arState.gameManager.startGame(with: [player1, player2])
-                    
-                    // 3. PieceManager가 윷판 앵커를 알 수 있도록 연결합니다.
-                    pieceManager.boardAnchor = boardManager.yutBoardAnchor
-                    
-                    // 4. 모든 준비가 끝났으니, 윷을 던질 준비 상태로 전환합니다.
-                    arState.gamePhase = .readyToThrow
-                }
-            }
-            
+            coordinator.setupNewGame()
+        
         case .showDestinationsForNewPiece:
+            coordinator.showDestinationsForNewPiece()
 
-            guard let arState = coordinator.arState else { return }
-            let gameManager = arState.gameManager
-            
-            // 1. 현재 플레이어의 말 중 판 밖에 있는 첫 번째 말을 찾습니다.
-            guard let newPiece = gameManager.currentPlayer.pieces.first(where: { $0.position == "_6_6" }),
-                  let yutResult = gameManager.yutResult
-            else {
-                print("말이없어잉")
-                return
-            }
-            
-            // 2. 그 말의 목적지를 계산합니다.
-            let destinations = gameManager.routeOptions(for: newPiece, yutResult: yutResult, currentRouteIndex: newPiece.routeIndex)
-            
-            if !destinations.isEmpty {
-                // 3. 목적지 타일들을 하이라이트합니다.
-                let destinationNames = destinations.map { $0.destinationID }
-                coordinator.pieceManager.highlightTiles(named: destinationNames)
-                
-                // 4. '새 말'을 선택된 것으로 상태에 저장하고, '목적지 선택' 단계로 전환합니다.
-                arState.selectedPiece = newPiece
-                arState.availableDestinations = destinationNames
-                arState.gamePhase = .selectingDestination
-            }
-
+        // setupNewGame에서 실행해도 괜찮을 듯
         case .preloadYutModels:
             coordinator.yutManager.preloadYutModels()
         
         case .startMonitoringMotion:
             coordinator.yutManager.startMonitoringMotion()
+            // 상태 변경 여기서?
             Task { @MainActor in
                 coordinator.arState?.gamePhase = .selectingPieceToMove
             }
+            
+        case .setYutResultForTesting(let result):
+            coordinator.yutThrowCompleted(with: result)
         }
+        
     }
 }

--- a/Yut/Yut/Features/ARGamePlay/Manager /PieceManager.swift
+++ b/Yut/Yut/Features/ARGamePlay/Manager /PieceManager.swift
@@ -68,7 +68,7 @@ final class PieceManager {
     
     // MARK: - Highlighting
     
-    // ✨ 1. 기존 함수를 '타일' 하이라이트 전용으로 이름을 명확하게 변경
+    // 하이라이트할 Tile Entity 반환
     func highlightTiles(named tileNames: [String]) {
         guard let boardEntity = boardAnchor?.children.first else {
             print("❌ 윷판 엔티티 없음")
@@ -83,19 +83,18 @@ final class PieceManager {
         }
     }
     
-    // ✨ 2. 제안하신 '말'들을 하이라이트하는 새로운 함수
+    // 하이라이트할 말 Entity 반환
     func highlightMovablePieces(_ pieces: [PieceModel]) {
         clearAllHighlights() // 이전에 있던 모든 하이라이트 제거
         
         for piece in pieces {
-            // PieceModel에서 AR Entity를 직접 가져옵니다.
             guard let pieceEntity = piece.entity as? ModelEntity else { continue }
             applyHighlight(to: pieceEntity)
         }
     }
     
     
-    // ✨ 3. 하이라이트를 적용하는 로직을 별도 함수로 분리 (코드 중복 제거)
+    // 인자로 받은 엔티티의 하이라이트 적용
     private func applyHighlight(to entity: ModelEntity) {
         guard let model = entity.model else { return }
         
@@ -113,37 +112,29 @@ final class PieceManager {
         entity.model = newModel
     }
     
-    // ✨ 4. 모든 하이라이트를 원래대로 되돌리는 함수
+    // 모든 하이라이트를 원래대로 되돌리는 함수
     func clearAllHighlights() {
-        // 딕셔너리에 저장된 모든 엔티티를 순회하며 원래 머티리얼로 복원
         for (entity, originalMaterial) in originalMaterials {
             entity.model?.materials = [originalMaterial]
         }
         originalMaterials.removeAll()
     }
     
-    // ✨ 판 밖에 있던 말을 처음으로 AR 씬에 추가하는 함수
-        func placePieceOnBoard(piece: PieceModel, on tileName: String) {
-            guard let destinationTile = boardAnchor?.findEntity(named: tileName) else {
-                print("❌ 목적지 \(tileName) 타일을 찾을 수 없습니다.")
-                return
-            }
-            
-            
-        
-            
-            
-            
-            
-            let pieceEntity = piece.entity // PlayerModel.load()가 이미 로드해 둔 엔티티
-            
-            pieceEntity.generateCollisionShapes(recursive: true)
-            pieceEntity.scale = [0.3, 8.0, 0.3]
-            pieceEntity.position = [0, 0.2, 0]
-            
-            destinationTile.addChild(pieceEntity)
-
-            
-            print("✅ \(piece.entity.name)을 \(tileName)에 처음으로 배치했습니다.")
+    // 판 밖에 있던 말을 처음으로 AR 씬에 추가하는 함수
+    func placePieceOnBoard(piece: PieceModel, on tileName: String) {
+        guard let destinationTile = boardAnchor?.findEntity(named: tileName) else {
+            print("❌ 목적지 \(tileName) 타일을 찾을 수 없습니다.")
+            return
         }
+        
+        let pieceEntity = piece.entity // PlayerModel.load()가 이미 로드해 둔 엔티티
+        
+        pieceEntity.generateCollisionShapes(recursive: true)
+        pieceEntity.scale = [0.3, 8.0, 0.3]
+        pieceEntity.position = [0, 0.2, 0]
+        
+        destinationTile.addChild(pieceEntity)
+        
+        print("✅ \(piece.entity.name)을 \(tileName)에 처음으로 배치했습니다.")
+    }
 }

--- a/Yut/Yut/Features/ARGamePlay/PlayView.swift
+++ b/Yut/Yut/Features/ARGamePlay/PlayView.swift
@@ -85,8 +85,7 @@ struct PlayView : View {
                     VStack {
                         InstructionView(text: "\(arState.gameManager.currentPlayer.name)의 턴: 움직일 말을 탭하세요.")
                         Spacer()
-                        
-                        // 만약 현재 플레이어가 판 밖에 둔 말이 있다면, '새 말 놓기' 버튼을 보여줍니다.
+
                         if arState.gameManager.currentPlayerHasOffBoardPieces {
                             RoundedBrownButton(title: "새 말 놓기", isEnabled: true) {
                                 arState.actionStream.send(.showDestinationsForNewPiece)

--- a/Yut/Yut/Features/ARGamePlay/PlayView.swift
+++ b/Yut/Yut/Features/ARGamePlay/PlayView.swift
@@ -61,6 +61,21 @@ struct PlayView : View {
                 case .readyToThrow:
                     InstructionView(text: "버튼을 눌러 윷을 던져랏")
                     Spacer()
+                    
+                    HStack(spacing: 10) {
+                        // YutResult의 모든 케이스를 순회하며 버튼을 만듭니다.
+                        ForEach(YutResult.allCases) { result in
+                            Button(result.displayText) {
+                                // 버튼을 누르면 테스트용 액션을 보냅니다.
+                                arState.actionStream.send(.setYutResultForTesting(result))
+                            }
+                            .padding()
+                            .background(Color.brown.opacity(0.8))
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                            .font(.system(size: 14, weight: .bold))
+                        }
+                    }
                     RoundedBrownButton(title: "윷 던지기 활성화!", isEnabled: true) {
                         arState.actionStream.send(.startMonitoringMotion)
                     }
@@ -70,7 +85,7 @@ struct PlayView : View {
                     VStack {
                         InstructionView(text: "\(arState.gameManager.currentPlayer.name)의 턴: 움직일 말을 탭하세요.")
                         Spacer()
-
+                        
                         // 만약 현재 플레이어가 판 밖에 둔 말이 있다면, '새 말 놓기' 버튼을 보여줍니다.
                         if arState.gameManager.currentPlayerHasOffBoardPieces {
                             RoundedBrownButton(title: "새 말 놓기", isEnabled: true) {

--- a/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
@@ -7,5 +7,5 @@ enum ARAction {
     case setupNewGame                       // 새 게임 시작
     case preloadYutModels                   // 윷 미리 선언
     case startMonitoringMotion              // 윷 던지기 감지 시작 (CoreMotion)
-
+    case setYutResultForTesting(YutResult)  // 테스트용 윷 결과 생성
 }

--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -11,7 +11,7 @@ import Foundation
 import SwiftUI
 import MultipeerConnectivity
 
-enum YutResult: Int {
+enum YutResult: Int, Identifiable, CaseIterable {
     case backdho = -1
     case dho = 1
     case gae = 2
@@ -21,6 +21,10 @@ enum YutResult: Int {
     
     var steps: Int { rawValue }
     var isExtraTurn: Bool { self == .yut || self == .mo }
+    
+    // ForEach를 위한 id
+    var id: Int { rawValue }
+
 }
 
 struct GameResult {

--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -24,7 +24,7 @@ enum YutResult: Int, Identifiable, CaseIterable {
     
     // ForEach를 위한 id
     var id: Int { rawValue }
-
+    
 }
 
 struct GameResult {
@@ -56,12 +56,11 @@ class GameManager :ObservableObject {
     @Published var result: GameResult? // 게임 최종 결과 반환
     @State private var userChooseToCarry: Bool = false // 업을지 말지 여부 상태 변수
     
-    // ✨ 현재 플레이어가 판 밖에 둔 말이 있는지 확인하는 프로퍼티 추가
-        var currentPlayerHasOffBoardPieces: Bool {
-            // currentPlayer의 말 중에 position이 "_6_6"인 것이 하나라도 있는지 확인
-            currentPlayer.pieces.contains { $0.position == "_6_6" }
-        }
-
+    // currentPlayer의 말 중에 position이 "_6_6"인 것이 하나라도 있는지 확인
+    var currentPlayerHasOffBoardPieces: Bool {
+        currentPlayer.pieces.contains { $0.position == "_6_6" }
+    }
+    
     
     func startGame(with players: [PlayerModel]) {
         self.players = players
@@ -181,29 +180,6 @@ class GameManager :ObservableObject {
     func endGame() {
         // Result의 gameEnded가 true이면 게임 종료 -> 게임 결과 화면 띄우고,
     }
-    
-//    init() {
-//        // TESTONLY
-//        let dummyEntity1 = Entity()
-//        let dummyEntity2 = Entity()
-//        
-//        let player1 = PlayerModel(
-//            name: "Player 1",
-//            sequence: 0,
-//            peerID: MCPeerID(displayName: UUID().uuidString),
-////            entities: [dummyEntity1, dummyEntity2]
-//        )
-//        
-//        let player2 = PlayerModel(
-//            name: "Player 2",
-//            sequence: 1,
-//            peerID: MCPeerID(displayName: UUID().uuidString),
-////            entities: [dummyEntity1, dummyEntity2]
-//        )
-//        self.players = [player1, player2]
-//        self.board = BoardModel()
-//        self.cellStates = [:]
-//        self.yutResult = nil
-//    }
+
 }
 

--- a/Yut/Yut/Features/Lobby/Models/PieceModel.swift
+++ b/Yut/Yut/Features/Lobby/Models/PieceModel.swift
@@ -21,6 +21,7 @@ class PieceModel {
         self.position = position
         do {
             let tokenEntity: Entity = try ModelEntity.load(named: owner.pieceEntity)
+            tokenEntity.name = self.id.uuidString
             self.entity = tokenEntity
         } catch {
             print("모델 로딩 실패: \(error)")


### PR DESCRIPTION

## 변경 사항 (Changes)
- 전체적인 흐름은 노션 GameLogic 쪽에 정리해 두었습니다!

**PlayerModel**
- Player 객체가 생성될 때 함께 생성되는 PieceModel 객체로 Entity 넘김
   (관련 부분 코드 정리가 필요할 듯, load 함수와 생성자가 하는 일이 같아요) with 세나

**ARCoordinator**
- setupNewGame() : 플레이어 객체 생성, 게임메니저에 넘겨줌

**GameManager**
- 말 이동 관련 로직들 추가

**GestureHandler**
- 각 단계 별로 탭된 엔티티의 정보를 추적하고 넘기는 작업 수행

**PieceManager**
- 넘겨받은 정보를 가진 엔티티를 하이라이트


## 추가 논의 사항
- 말이 움직일 수 있는 경우가 있을까? 즉 routeOption이 nil 인 경우
- 여러번 옮기니까 터치가 안되는 이슈 발생 ->>> 고칠게요 (영상참고)

https://github.com/user-attachments/assets/8d155de7-0c60-4acf-aab8-bc2c10e329c0

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: Closes #123
-->
Closes #109 





