### PR TITLE
fix: 경로 밖으로 벗어났을 때 예외처리

### DIFF
--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -111,7 +111,7 @@ class GameManager :ObservableObject {
         if targetCellID == "end" || targetCellID == "start" {
             return GameResult(
                 piece: piece,
-                cell: targetCellID,
+                cell: "_6_6",
                 didCapture: false,
                 didCarry: false,
                 gameEnded: true

--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -94,7 +94,14 @@ class GameManager :ObservableObject {
                 if nextIndex < route.count {
                     let destinationID = route[nextIndex]
                     options.append((routeIndex, destinationID))
+                } else if (nextIndex < 0){
+                    let destinationID = "start"
+                    options.append((routeIndex, destinationID))
+                } else {
+                    let destinationID = "end"
+                    options.append((routeIndex, destinationID))
                 }
+                
             }
         }
         return options


### PR DESCRIPTION

<img width="547" height="147" alt="스크린샷 2025-07-30 03 32 23" src="https://github.com/user-attachments/assets/8dd6b8ea-9cd7-48a1-ac53-d7430c66c5cc" />


아 커밋 메세지에 괄호를 안 닫았네 -> 열린 결말입니다 막이래

어떤 문제가 있었냐면
cellID가 start나 end일 때 gameEnded는 true로 바뀌나,
 targetCellID가 start, end로 유지되어 말판을 벗어나 말이 배치되었는데요,
이를 막고자 cellID가 start나 end일 때 targetCellID를 항상 _6_6으로 두어 게임은 끝났지만 말은 _6_6인 시작점에 있도록 했습니다!
