### PR TITLE
fix: start에 도달하면 _5_6으로 이동하기

### DIFF
--- a/Yut/Yut/Features/Lobby/Manager/GameManager.swift
+++ b/Yut/Yut/Features/Lobby/Manager/GameManager.swift
@@ -115,7 +115,7 @@ class GameManager :ObservableObject {
     
     @discardableResult
     func applyMoveResult(piece: PieceModel, to targetCellID: String, userChooseToCarry: Bool) -> GameResult {
-        if targetCellID == "end" || targetCellID == "start" {
+        if targetCellID == "end" {
             return GameResult(
                 piece: piece,
                 cell: "_6_6",
@@ -123,7 +123,16 @@ class GameManager :ObservableObject {
                 didCarry: false,
                 gameEnded: true
             )
+        } else if (targetCellID == "start") {
+            return GameResult(
+                piece: piece,
+                cell: "_5_6",
+                didCapture: false,
+                didCarry: false,
+                gameEnded: true
+            )
         }
+        
         
         let existingPieces = cellStates[targetCellID] ?? []
         


### PR DESCRIPTION
어차피 start에서 뒤로갈 수 있는 칸 수는 한 칸밖에 안돼서 그냥 바로 _5_6으로 말을 이동 시킵니다.
이후 로직은 원래와 같음 ! 배열을 초과하면 게임이 끝나게 됩니당