### PR TITLE
feat: 기기 한 대로 플레이하는 버전의 WaitingRoom 구현 & players 연결(완료✨)

### DIFF
--- a/Yut/Yut/APP/RootView.swift
+++ b/Yut/Yut/APP/RootView.swift
@@ -9,6 +9,14 @@ import SwiftUI
 
 struct RootView: View {
     @StateObject private var navigationManager = NavigationManager()
+    @StateObject private var viewModel: WaitingRoomViewModel
+    private let arCoordinator = ARCoordinator()
+
+    init() {
+        let manager = NavigationManager()
+        _navigationManager = StateObject(wrappedValue: manager)
+        _viewModel = StateObject(wrappedValue: WaitingRoomViewModel(navigationManager: manager))
+    }
 
     var body: some View {
         NavigationStack(path: $navigationManager.path) {
@@ -24,11 +32,17 @@ struct RootView: View {
                     case .roomList:
                         RoomListView()
                     case .waitingRoom(let room):
-                        WaitingRoomView(room: room, navigationManager: navigationManager)
+                        WaitingRoomView(
+                            room: room,
+                            navigationManager: navigationManager,
+                            arCoordinator: arCoordinator
+                        )
+                        .environmentObject(viewModel)
                     case .winner:
                         WinnerView()
                     case .playView:
-                        PlayView()
+                        PlayView(arCoordinator: arCoordinator)
+                            .environmentObject(viewModel)
                     }
                 }
         }

--- a/Yut/Yut/APP/YutApp.swift
+++ b/Yut/Yut/APP/YutApp.swift
@@ -11,8 +11,12 @@ import SwiftUI
 struct YutApp: App {
     var body: some Scene {
         WindowGroup {
-            PlayView()
-//            RootView()
+//            let dummyNavigationManager = NavigationManager()
+//            let dummyViewModel = WaitingRoomViewModel(navigationManager: dummyNavigationManager)
+//            PlayView(viewModel: dummyViewModel)
+            
+            RootView()
         }
+        
     }
 }

--- a/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
+++ b/Yut/Yut/Features/ARGamePlay/ARCoordinator.swift
@@ -119,28 +119,32 @@ class ARCoordinator: NSObject, ARSessionDelegate {
     // MARK: - Game Flow Control
     
     // '새 게임 준비' 액션을 처리하는 함수
-    func setupNewGame() {
-        Task {
-            // Main 스레드
-            // GameManager 설정, 게임 상태 변경
-            @MainActor in
-            
-            // PlayerModel 로드 (PeerID 임시값)
-//            let player1 = PlayerModel(name: "노랑", sequence: 1, peerID: MCPeerID(displayName: "Player1"))
-//            let player2 = PlayerModel(name: "초록", sequence: 2, peerID: MCPeerID(displayName: "Player2"))
-            let players = MPCManager.shared.players
-            
+    func setupNewGame(with players: [PlayerModel]) {
+        let safePlayers = players
+        
+        Task { @MainActor in
             guard let arState = self.arState else { return }
             
-            // GameManager에 실제 플레이어 정보로 새 게임을 설정
-//            arState.gameManager.startGame(with: [player1, player2])
             arState.gameManager.startGame(with: players)
-            
-            // PieceManager 윷판 앵커를 알 수 있도록 연결
             self.pieceManager.boardAnchor = self.boardManager.yutBoardAnchor
-            
-            // 준비 끝, 상태 전환
             arState.gamePhase = .readyToThrow
+            
+//            // PlayerModel 로드 (PeerID 임시값)
+////            let player1 = PlayerModel(name: "노랑", sequence: 1, peerID: MCPeerID(displayName: "Player1"))
+////            let player2 = PlayerModel(name: "초록", sequence: 2, peerID: MCPeerID(displayName: "Player2"))
+//            let players = MPCManager.shared.players
+//            
+//            guard let arState = self.arState else { return }
+//            
+//            // GameManager에 실제 플레이어 정보로 새 게임을 설정
+////            arState.gameManager.startGame(with: [player1, player2])
+//            arState.gameManager.startGame(with: players)
+//            
+//            // PieceManager 윷판 앵커를 알 수 있도록 연결
+//            self.pieceManager.boardAnchor = self.boardManager.yutBoardAnchor
+//            
+//            // 준비 끝, 상태 전환
+//            arState.gamePhase = .readyToThrow
             
         }
     }

--- a/Yut/Yut/Features/ARGamePlay/Managers/ActionStreamHandler.swift
+++ b/Yut/Yut/Features/ARGamePlay/Managers/ActionStreamHandler.swift
@@ -27,8 +27,8 @@ final class ActionStreamHandler {
         case .disablePlaneVisualization:
             coordinator.planeManager.disablePlaneVisualization()
             
-        case .setupNewGame:
-            coordinator.setupNewGame()
+        case .setupNewGame(let players):
+            coordinator.setupNewGame(with: players)
         
         case .showDestinationsForNewPiece:
             coordinator.showDestinationsForNewPiece()

--- a/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
+++ b/Yut/Yut/Features/ARGamePlay/State/Enums/ARAction.swift
@@ -4,7 +4,7 @@ enum ARAction {
     case fixBoardPosition                   // 윷판을 평면 위에 고정
     case disablePlaneVisualization          // 평면 시각화 비활성화
     case showDestinationsForNewPiece        // 새 말 놓을 위치 하이라이트
-    case setupNewGame                       // 새 게임 시작
+    case setupNewGame(players: [PlayerModel]) // 새 게임 시작
     case preloadModels                      // 에셋 미리 선언
     case startMonitoringMotion              // 윷 던지기 감지 시작 (CoreMotion)
     case setYutResultForTesting(YutResult)  // 테스트용 윷 결과 생성

--- a/Yut/Yut/Features/Lobby/Views/NameInput/NameInputFormView.swift
+++ b/Yut/Yut/Features/Lobby/Views/NameInput/NameInputFormView.swift
@@ -72,7 +72,7 @@ struct NameInputFormView: View {
                     onSubmit()
                 } label: {
                     RoundedRectangle(cornerRadius: 34)
-                        .fill(Color("Brown1"))
+                        .fill(.brown1)
                         .frame(maxWidth: .infinity)
                         .frame(height: 64)
                         .overlay(

--- a/Yut/Yut/Features/Lobby/Views/RoomList/RoomListView.swift
+++ b/Yut/Yut/Features/Lobby/Views/RoomList/RoomListView.swift
@@ -15,7 +15,6 @@ struct RoomListView: View {
     var body: some View {
         ZStack {
             Color.white1
-            //                .edgesIgnoringSafeArea(.all)
                 .ignoresSafeArea()
             
             ScrollView {
@@ -38,7 +37,6 @@ struct RoomListView: View {
                     Spacer()
                 }
                 .padding(.top, 40)
-                .padding(.horizontal, 20)
             }
         }
         .gesture(
@@ -93,8 +91,7 @@ struct RoomListView: View {
     }
 }
 
-
-#Preview {
-    RoomListView()
-        .environmentObject(NavigationManager())
-}
+//#Preview {
+//    RoomListView()
+//        .environmentObject(NavigationManager())
+//}

--- a/Yut/Yut/Features/Lobby/Views/RoomList/RoomListView.swift
+++ b/Yut/Yut/Features/Lobby/Views/RoomList/RoomListView.swift
@@ -46,10 +46,10 @@ struct RoomListView: View {
                 }
             }
         )
-        .onDisappear {
-            MPCManager.shared.disconnect()
-            MPCManager.shared.players.removeAll()
-        }
+//        .onDisappear {
+//            MPCManager.shared.disconnect()
+//            MPCManager.shared.players.removeAll()
+//        }
         .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.white1, for: .navigationBar)

--- a/Yut/Yut/Features/Lobby/Views/WaitingRoom/AddPlayerCard.swift
+++ b/Yut/Yut/Features/Lobby/Views/WaitingRoom/AddPlayerCard.swift
@@ -1,0 +1,39 @@
+//
+//  AddPlayerCard.swift
+//  Yut
+//
+//  Created by soyeonsoo on 7/30/25.
+//
+
+import SwiftUI
+
+struct AddPlayerCard: View {
+    var action: () -> Void
+    
+    var body: some View {
+        VStack {
+            ZStack {
+                Circle()
+                    .fill(Color.white2)
+                    .frame(width: 135, height: 135)
+                
+                Image(systemName: "plus")
+                    .font(.system(size: 40, weight: .bold))
+                    .foregroundColor(.brown4)
+            }
+            .padding(.top, 36)
+            .padding(.bottom, 25)
+            .frame(
+                width: UIScreen.main.bounds.width / 2 - 24,
+                height: 289
+            )
+            .background(.white.opacity(0.35))
+            .cornerRadius(12)
+            .shadow(color: .black.opacity(0.06), radius: 12, x: 0, y: 4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(.white.opacity(0.35), lineWidth: 1)
+            )
+        }
+    }
+}

--- a/Yut/Yut/Features/Lobby/Views/WaitingRoom/AddPlayerModalView.swift
+++ b/Yut/Yut/Features/Lobby/Views/WaitingRoom/AddPlayerModalView.swift
@@ -1,0 +1,79 @@
+//
+//  AddPlayerModalView.swift
+//  Yut
+//
+//  Created by soyeonsoo on 7/30/25.
+//
+
+import SwiftUI
+
+struct AddPlayerModalView: View {
+    @Binding var isPresented: Bool
+    @Binding var nickname: String
+    
+    var onSubmit: () -> Void
+    
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .padding(.horizontal, -20)
+                .onTapGesture {
+                    isPresented = false
+                }
+            
+            VStack(spacing: 20) {
+                Text("닉네임을 입력하세요")
+                    .font(.pretendard(.regular, size: 22))
+                    .padding(.top, 32)
+
+                TextField("", text: $nickname)
+                    .frame(width: 218, height: 34)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 10)
+                    .background(
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.white.opacity(0.14))
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.brown, lineWidth: 1)
+                        }
+                    )
+                    .onChange(of: nickname) {
+                        if $0.count > 10 {
+                            nickname = String($0.prefix(10))
+                        }
+                    }
+                
+                Button("추가") {
+                    onSubmit()
+                    isPresented = false
+                    nickname = ""
+                }
+                .disabled(nickname.isEmpty)
+                .frame(maxWidth: .infinity, maxHeight: 50)
+                .background(nickname.isEmpty ? Color.gray.opacity(0.3) : Color.brown4)
+                .foregroundColor(.white)
+                .cornerRadius(25)
+                .padding(.horizontal, 30)
+                .padding(.bottom, 24)
+            }
+            .background(.ultraThinMaterial.opacity(0.8))
+            .background(.white1.opacity(0.8))
+            .cornerRadius(24)
+            .padding(18)
+            .shadow(radius: 8)
+            .transition(.scale)
+            HStack {
+                Spacer()
+                Text("\(nickname.count)/10")
+                    .font(.system(size: 15))
+                    .foregroundColor(.brown5)
+            }
+            .padding(.trailing, 62)
+            .padding(.bottom, 16)
+        }
+        .transition(.opacity)
+        .animation(.easeInOut, value: isPresented)
+    }
+}

--- a/Yut/Yut/Features/Lobby/Views/WaitingRoom/AddPlayerModalView.swift
+++ b/Yut/Yut/Features/Lobby/Views/WaitingRoom/AddPlayerModalView.swift
@@ -71,7 +71,7 @@ struct AddPlayerModalView: View {
                     .foregroundColor(.brown5)
             }
             .padding(.trailing, 62)
-            .padding(.bottom, 16)
+            .padding(.bottom, 18)
         }
         .transition(.opacity)
         .animation(.easeInOut, value: isPresented)

--- a/Yut/Yut/Features/Lobby/Views/WaitingRoom/PlayerCard.swift
+++ b/Yut/Yut/Features/Lobby/Views/WaitingRoom/PlayerCard.swift
@@ -40,5 +40,5 @@ struct PlayerCard: View {
 }
 
 //#Preview {
-//    PlayerCard(player: PlayerModel(name: "sena", sequence: 1, peerID: MCPeerID(displayName: "sena")))
+//    PlayerCard(player: PlayerModel(name: "sena", sequence: 1, peerID: 12, isHost: true))
 //}

--- a/Yut/Yut/Features/Lobby/Views/WaitingRoom/WaitingRoomViewModel.swift
+++ b/Yut/Yut/Features/Lobby/Views/WaitingRoom/WaitingRoomViewModel.swift
@@ -13,39 +13,42 @@ import Combine
 final class WaitingRoomViewModel: ObservableObject {
     @Published var showLeaveAlert = false
     @Published var players: [PlayerModel] = []
-
+    
     private let mpcManager = MPCManager.shared
     private let navigationManager: NavigationManager
     private var cancellables = Set<AnyCancellable>()
-
+    
     init(navigationManager: NavigationManager) {
         self.navigationManager = navigationManager
-        
-        // players를 mpcManager.players와 실시간 동기화
-        mpcManager.$players
+        MPCManager.shared.$players
             .receive(on: RunLoop.main)
             .assign(to: &$players)
+        
+        // players를 mpcManager.players와 실시간 동기화
+        //        mpcManager.$players
+        //            .receive(on: RunLoop.main)
+        //            .assign(to: &$players)
     }
-
-// MPC ver.
-//    func addPlayer(name: String) async {
-//        let newPlayer = await PlayerModel.load(
-//            name: name,
-//            sequence: mpcManager.players.count + 1,
-//            peerID: MCPeerID(displayName: name),
-//            isHost: false
-//        )
-//        players.append(newPlayer)
-//        mpcManager.players.append(newPlayer)
-//        if mpcManager.isHost {
-//            mpcManager.sendPlayersUpdate()
-//        }
-//    }
+    
+    // MPC ver.
+    //    func addPlayer(name: String) async {
+    //        let newPlayer = await PlayerModel.load(
+    //            name: name,
+    //            sequence: mpcManager.players.count + 1,
+    //            peerID: MCPeerID(displayName: name),
+    //            isHost: false
+    //        )
+    //        players.append(newPlayer)
+    //        mpcManager.players.append(newPlayer)
+    //        if mpcManager.isHost {
+    //            mpcManager.sendPlayersUpdate()
+    //        }
+    //    }
     
     // Single Device ver.
     func addPlayer(named name: String) {
         guard players.count < 4 else { return }
-
+        
         let newPlayer = PlayerModel(
             name: name,
             sequence: players.count + 1,
@@ -53,12 +56,13 @@ final class WaitingRoomViewModel: ObservableObject {
             isHost: players.isEmpty
         )
         players.append(newPlayer)
+        mpcManager.players.append(newPlayer)
     }
-
-//    func sendStartGameSignal() {
-//        NotificationCenter.default.post(name: .gameStarted, object: nil)
-//    }
-
+    
+    //    func sendStartGameSignal() {
+    //        NotificationCenter.default.post(name: .gameStarted, object: nil)
+    //    }
+    
     func leaveRoom() {
         if mpcManager.isHost {
             // 1. 생성된 방 목록에서 제거
@@ -78,7 +82,7 @@ final class WaitingRoomViewModel: ObservableObject {
             navigationManager.pop()
         }
     }
-
+    
     var buttonTitle: String {
         let mapping = [2: "둘이서", 3: "셋이서", 4: "넷이서"]
         // Single Device ver.
@@ -86,7 +90,7 @@ final class WaitingRoomViewModel: ObservableObject {
         // MPC ver.
         // return mapping[mpcManager.players.count].map { "\($0) 윷놀이 시작하기" } ?? "인원 기다리는 중..."
     }
-
+    
     var isHost: Bool {
         mpcManager.isHost
     }

--- a/Yut/Yut/Features/Lobby/Views/WaitingRoom/WaitingRoomViewModel.swift
+++ b/Yut/Yut/Features/Lobby/Views/WaitingRoom/WaitingRoomViewModel.swift
@@ -27,18 +27,32 @@ final class WaitingRoomViewModel: ObservableObject {
             .assign(to: &$players)
     }
 
-    func addPlayer(name: String) async {
-        let newPlayer = await PlayerModel.load(
+// MPC ver.
+//    func addPlayer(name: String) async {
+//        let newPlayer = await PlayerModel.load(
+//            name: name,
+//            sequence: mpcManager.players.count + 1,
+//            peerID: MCPeerID(displayName: name),
+//            isHost: false
+//        )
+//        players.append(newPlayer)
+//        mpcManager.players.append(newPlayer)
+//        if mpcManager.isHost {
+//            mpcManager.sendPlayersUpdate()
+//        }
+//    }
+    
+    // Single Device ver.
+    func addPlayer(named name: String) {
+        guard players.count < 4 else { return }
+
+        let newPlayer = PlayerModel(
             name: name,
-            sequence: mpcManager.players.count + 1,
+            sequence: players.count + 1,
             peerID: MCPeerID(displayName: name),
-            isHost: false
+            isHost: players.isEmpty
         )
         players.append(newPlayer)
-        mpcManager.players.append(newPlayer)
-        if mpcManager.isHost {
-            mpcManager.sendPlayersUpdate()
-        }
     }
 
 //    func sendStartGameSignal() {
@@ -67,7 +81,10 @@ final class WaitingRoomViewModel: ObservableObject {
 
     var buttonTitle: String {
         let mapping = [2: "둘이서", 3: "셋이서", 4: "넷이서"]
-        return mapping[mpcManager.players.count].map { "\($0) 윷놀이 시작하기" } ?? "인원 기다리는 중..."
+        // Single Device ver.
+        return mapping[players.count].map {"\($0) 윷놀이 시작하기"} ?? "인원 모으는 중..."
+        // MPC ver.
+        // return mapping[mpcManager.players.count].map { "\($0) 윷놀이 시작하기" } ?? "인원 기다리는 중..."
     }
 
     var isHost: Bool {


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->

https://github.com/user-attachments/assets/8877877c-9c31-49be-b65e-a897d220438a


MPC 기능은 잠시 접어두고 기기 한 대로 여럿이 플레이하는 방식으로 전환합니다.
이에 따라 WaitingRoom에서의 인원 추가 방식을 변경합니다.
비어있는 자리를 누르면 닉네임을 입력해 플레이어를 추가하는 식으루요.

입력받은 players 닉네임 정보 배열을 ARCoordinator에 넘깁니다.
게임이 돌아갑니다!!!

MPC 방식도 남겨두었습니다

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: Closes #123
-->
Closes #166 

## 추가 정보

너무 안 돼서 울고 싶었는데 원띵이 고래밥 주셔서 해냈다!
ㅠㅠ
